### PR TITLE
feat: Centralize app support files under bundle ID, redirect frontend logs to file, and enhance log export to include both frontend and backend logs.

### DIFF
--- a/frontend/SuperSay/SuperSay/Services/HistoryManager.swift
+++ b/frontend/SuperSay/SuperSay/Services/HistoryManager.swift
@@ -4,11 +4,17 @@ import Combine
 class HistoryManager: ObservableObject {
     @Published var history: [HistoryEntry] = []
     
-    private let url = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0].appendingPathComponent("history.json")
+    private var url: URL {
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.himudigonda.SuperSay"
+        return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent(bundleID)
+            .appendingPathComponent("history.json")
+    }
     
     init() {
         // Ensure directory exists
-        let folder = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.himudigonda.SuperSay"
+        let folder = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0].appendingPathComponent(bundleID)
         try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
         loadHistory()
     }

--- a/frontend/SuperSay/SuperSay/Services/LaunchManager.swift
+++ b/frontend/SuperSay/SuperSay/Services/LaunchManager.swift
@@ -34,7 +34,8 @@ class LaunchManager: ObservableObject {
     }
     
     func prepare() async {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.himudigonda.SuperSay"
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0].appendingPathComponent(bundleID)
         let executableURL = appSupport.appendingPathComponent("SuperSayServer/SuperSayServer")
         
         // 1. If binary exists, we are potentially ready

--- a/frontend/SuperSay/SuperSay/SuperSayApp.swift
+++ b/frontend/SuperSay/SuperSay/SuperSayApp.swift
@@ -17,6 +17,24 @@ struct SuperSayApp: App {
     private let backend: BackendService
     
     init() {
+        // 1. REDIRECT FRONTEND LOGS TO FILE
+        let bundleID = Bundle.main.bundleIdentifier ?? "com.himudigonda.SuperSay"
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0].appendingPathComponent(bundleID)
+        
+        // Ensure directory exists
+        try? FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
+        
+        let logURL = appSupport.appendingPathComponent("frontend.log")
+        
+        // Clear old log
+        try? "".write(to: logURL, atomically: true, encoding: .utf8)
+        
+        // Redirect stdout and stderr to the log file
+        freopen(logURL.path, "a+", stdout)
+        freopen(logURL.path, "a+", stderr)
+        
+        print("--- SuperSay Frontend Log Started: \(Date()) ---")
+        
         // Create instances
         let audioInstance = AudioService()
         let historyInstance = HistoryManager()

--- a/frontend/SuperSay/SuperSay/ViewModels/DashboardViewModel.swift
+++ b/frontend/SuperSay/SuperSay/ViewModels/DashboardViewModel.swift
@@ -264,7 +264,7 @@ class DashboardViewModel: ObservableObject {
     }
     func exportLogs() {
         Task {
-            await backend.exportLogs()
+            backend.exportLogs()
         }
     }
 }


### PR DESCRIPTION
## Description
Please include a summary of the change and which issue is fixed.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
- [x] Unit Tests
- [x] Manual Verification (Describe below)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation


This pull request standardizes the use of the application support directory by including the app's bundle identifier as a subdirectory throughout the codebase. It also introduces improved logging by redirecting frontend logs to a file and enhancing the log export functionality to include both backend and frontend logs with timestamps. These changes improve organization, maintainability, and debugging capabilities.

**Directory Structure Standardization:**
* All references to the application support directory now append the app's bundle identifier, ensuring data and logs are isolated per app install and avoiding conflicts. This affects `BackendService`, `HistoryManager`, and `LaunchManager`. [[1]](diffhunk://#diff-a459fac42e03bdc0568390151280ff3edc6ad0783a2b0f25eff6c896463900ceL33-R37) [[2]](diffhunk://#diff-bd7dcae3a34c2c03323f43846fbd4956da8b998c7b6297a672a311e0837c5a48L7-R17) [[3]](diffhunk://#diff-11f2e27154f93338bc43c2b9fb9638285dd81b9b560fa3b67d9e35f8441c249bL37-R38)

**Logging Improvements:**
* The frontend now redirects both `stdout` and `stderr` to a `frontend.log` file in the app support directory, clearing the log on each launch. This helps with debugging and persistent log storage.
* The log export feature now copies both `backend.log` and `frontend.log` to the user's Desktop with a timestamp in the filename, and opens the Desktop in Finder for convenience. It also prints status messages for each log.

**Minor Updates:**
* The `exportLogs` call in `DashboardViewModel` was updated to remove an unnecessary `await`, since the method is now synchronous.